### PR TITLE
Created RoomData Scriptable Object Class and Random-Grid-Walk Dungeon Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+/Assets/ProcGenScripts/TestRoom.asset
+/Assets/ProcGenScripts/TestRoom.asset.meta

--- a/Assets/ProcGenScripts/DungeonGenerator.cs
+++ b/Assets/ProcGenScripts/DungeonGenerator.cs
@@ -1,30 +1,30 @@
 using System.Collections;
 using System.Collections.Generic;
+using System;
 using Unity.VisualScripting;
 using UnityEditor;
 using UnityEngine;
 
 public class DungeonGenerator : MonoBehaviour
 {
-    public List<RoomData> spawnableRooms = new();
-    private List<Room> generatedRooms = new();
-    public int minRooms = 1;
-    public int maxRooms = 2;
+    public readonly List<RoomData> spawnableRooms = new();
+    private readonly List<Room> _generatedRooms = new();
+    [SerializeField]
+    private int _minRooms = 1;
+    [SerializeField]
+    private int _maxRooms = 1;
+    public int MinRooms { get => _minRooms; set => _minRooms = Math.Max(value, 0); }
+    public int MaxRooms { get => _maxRooms; set => _maxRooms = Math.Max(value, _minRooms); }
 
-    public void Start()
+    /// <summary>
+    /// Generates a dungeon with a random number of rooms between the min and max room count.
+    /// It chooses rooms from the spawnableRooms list and connects them together.
+    /// </summary>
+    /// <returns>This coroutine.</returns>
+    public IEnumerator GenerateDungeon()
     {
-        StartCoroutine(GenerateDungeon());
-    }
-
-    //IEnumerator Start()
-    //{
-    //    yield return StartCoroutine(GenerateDungeon());
-    //}
-
-    IEnumerator GenerateDungeon()
-    {
-        int numRooms = Random.Range(minRooms, maxRooms);
-        RoomData baseRoom = spawnableRooms[Random.Range(0, spawnableRooms.Count)];
+        int numRooms = UnityEngine.Random.Range(_minRooms, _maxRooms);
+        RoomData baseRoom = spawnableRooms[UnityEngine.Random.Range(0, spawnableRooms.Count)];
         
         Room currentRoom = new GameObject().AddComponent<Room>();
         currentRoom.Init(baseRoom, Vector3.zero);
@@ -38,40 +38,66 @@ public class DungeonGenerator : MonoBehaviour
                 currentRoom = currentRoom.GetRoomFromDirection(dir);
                 continue;
             }
-            RoomData roomType = spawnableRooms[Random.Range(0, spawnableRooms.Count)];
+            RoomData roomType = spawnableRooms[UnityEngine.Random.Range(0, spawnableRooms.Count)];
             Room newRoom = new GameObject().AddComponent<Room>();
             Vector3 position = currentRoom.transform.position;
             // Calculate the position offset of the new room based on the direction
             position.x += dir switch
             { 
-                RoomData.Dir.East => roomType.Width / 2,
-                RoomData.Dir.West => -roomType.Width / 2,
+                RoomData.Dir.East => roomType.Width,
+                RoomData.Dir.West => -roomType.Width,
                 _ => 0,
             };
             position.y += dir switch
             {
-                RoomData.Dir.North => roomType.Height / 2,
-                RoomData.Dir.South => -roomType.Height / 2,
+                RoomData.Dir.North => roomType.Height,
+                RoomData.Dir.South => -roomType.Height,
                 _ => 0,
             };
             newRoom.Init(roomType, position);
-            generatedRooms.Add(newRoom);
+            switch (dir)
+            {
+                case RoomData.Dir.North:
+                    currentRoom.NorthRoom = newRoom;
+                    newRoom.SouthRoom = currentRoom;
+                    break;
+                case RoomData.Dir.East:
+                    currentRoom.EastRoom = newRoom;
+                    newRoom.WestRoom = currentRoom;
+                    break;
+                case RoomData.Dir.South:
+                    currentRoom.SouthRoom = newRoom;
+                    newRoom.NorthRoom = currentRoom;
+                    break;
+                case RoomData.Dir.West:
+                    currentRoom.WestRoom = newRoom;
+                    newRoom.EastRoom = currentRoom;
+                    break;
+            }
+            _generatedRooms.Add(newRoom);
+            currentRoom = newRoom;
             roomGenCount++;
-            yield return new WaitForSecondsRealtime(1f);
+            yield return new WaitForSecondsRealtime(.25f);
         }
     }
 
+    /// <summary>
+    /// Draw the colliders of the generated rooms in the editor.
+    /// </summary>
     private void DebugDraw()
     {
-        foreach (var item in generatedRooms)
+        foreach (Room room in _generatedRooms)
         {
-            foreach (BoxCollider2D collider in item.GetComponents<BoxCollider2D>())
+            foreach (BoxCollider2D collider in room.GetComponents<BoxCollider2D>())
             {
                 Gizmos.DrawWireCube(collider.bounds.center, collider.bounds.size);
             }
         }
     }
 
+    /// <summary>
+    /// Draw the colliders of the generated rooms in the editor every unity message callback.
+    /// </summary>
     private void OnDrawGizmos()
     {
         DebugDraw();

--- a/Assets/ProcGenScripts/DungeonGenerator.cs
+++ b/Assets/ProcGenScripts/DungeonGenerator.cs
@@ -1,0 +1,79 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEditor;
+using UnityEngine;
+
+public class DungeonGenerator : MonoBehaviour
+{
+    public List<RoomData> spawnableRooms = new();
+    private List<Room> generatedRooms = new();
+    public int minRooms = 1;
+    public int maxRooms = 2;
+
+    public void Start()
+    {
+        StartCoroutine(GenerateDungeon());
+    }
+
+    //IEnumerator Start()
+    //{
+    //    yield return StartCoroutine(GenerateDungeon());
+    //}
+
+    IEnumerator GenerateDungeon()
+    {
+        int numRooms = Random.Range(minRooms, maxRooms);
+        RoomData baseRoom = spawnableRooms[Random.Range(0, spawnableRooms.Count)];
+        
+        Room currentRoom = new GameObject().AddComponent<Room>();
+        currentRoom.Init(baseRoom, Vector3.zero);
+        int roomGenCount = 1;
+        while (roomGenCount < numRooms)
+        {
+            RoomData.Dir dir = currentRoom.GetRandomDirection();
+            // If the room already has a room in the direction, move to that room
+            if (currentRoom.GetRoomFromDirection(dir) != null)
+            {
+                currentRoom = currentRoom.GetRoomFromDirection(dir);
+                continue;
+            }
+            RoomData roomType = spawnableRooms[Random.Range(0, spawnableRooms.Count)];
+            Room newRoom = new GameObject().AddComponent<Room>();
+            Vector3 position = currentRoom.transform.position;
+            // Calculate the position offset of the new room based on the direction
+            position.x += dir switch
+            { 
+                RoomData.Dir.East => roomType.Width / 2,
+                RoomData.Dir.West => -roomType.Width / 2,
+                _ => 0,
+            };
+            position.y += dir switch
+            {
+                RoomData.Dir.North => roomType.Height / 2,
+                RoomData.Dir.South => -roomType.Height / 2,
+                _ => 0,
+            };
+            newRoom.Init(roomType, position);
+            generatedRooms.Add(newRoom);
+            roomGenCount++;
+            yield return new WaitForSecondsRealtime(1f);
+        }
+    }
+
+    private void DebugDraw()
+    {
+        foreach (var item in generatedRooms)
+        {
+            foreach (BoxCollider2D collider in item.GetComponents<BoxCollider2D>())
+            {
+                Gizmos.DrawWireCube(collider.bounds.center, collider.bounds.size);
+            }
+        }
+    }
+
+    private void OnDrawGizmos()
+    {
+        DebugDraw();
+    }
+}

--- a/Assets/ProcGenScripts/DungeonGenerator.cs.meta
+++ b/Assets/ProcGenScripts/DungeonGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39c397fcb677058439ea0786bdd5292f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ProcGenScripts/Room.cs
+++ b/Assets/ProcGenScripts/Room.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Room : MonoBehaviour
+{
+    public readonly int x, y, xSize, ySize;
+    public readonly int doorSize;
+    public readonly bool North, East, South, West;
+    public Room NorthRoom = null, EastRoom = null, SouthRoom = null, WestRoom = null;
+    private List<RoomData.Dir> availableDirections = new();
+    public bool visited;
+    private bool isStart;
+    private bool isEnd;
+    private Dictionary<string, Collider2D> colliders = new();
+    public bool Started => isStart;
+    public bool Ended => isEnd;
+    private enum ColliderType
+    {
+        NorthWest,
+        NorthEast,
+        SouthWest,
+        SouthEast,
+        WestNorth,
+        WestSouth,
+        EastNorth,
+        EastSouth,
+        NorthDoor,
+        EastDoor,
+        SouthDoor,
+        WestDoor
+    }
+
+    public Room(RoomData roomData)
+    {
+        x = roomData.X;
+        y = roomData.Y;
+        xSize = roomData.Width;
+        ySize = roomData.Height;
+        doorSize = roomData.DoorSize;
+        North = roomData.connectDirs[RoomData.Dir.North];
+        East = roomData.connectDirs[RoomData.Dir.East]; 
+        South = roomData.connectDirs[RoomData.Dir.South];
+        West = roomData.connectDirs[RoomData.Dir.West];
+        if (North) availableDirections.Add(RoomData.Dir.North);
+        if (East) availableDirections.Add(RoomData.Dir.East);
+        if (South) availableDirections.Add(RoomData.Dir.South);
+        if (West) availableDirections.Add(RoomData.Dir.West);
+        visited = false;
+        isStart = false;
+        isEnd = false;
+        // Create Colliders
+        colliders.Add("NorthWest", CreateCollider(ColliderType.NorthWest));
+    }
+
+    /// <summary>
+    /// Get a random direction from the available directions.
+    /// </summary>
+    /// <returns>A direction that this room can connect to or North if room has no available connections.</returns>
+    public RoomData.Dir GetRandomDirection()
+    {
+        if (availableDirections.Count == 0) return RoomData.Dir.North;
+        return availableDirections[Random.Range(0, availableDirections.Count)];
+    }
+
+    /// <summary>
+    /// Creates a collider for the room in the specified slot.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    private Collider2D CreateCollider(ColliderType type)
+    {
+        GameObject go = new GameObject();
+        go.transform.position = new Vector3(x, y, 0);
+        go.transform.parent = transform;
+        BoxCollider2D collider = go.AddComponent<BoxCollider2D>();
+        switch (type)
+        {
+            case ColliderType.NorthDoor:
+                collider.size = new Vector2(doorSize, doorSize);
+                collider.offset = new Vector2(-xSize / 2, ySize / 2);
+                break;
+        }
+        return collider;
+    }   
+}

--- a/Assets/ProcGenScripts/Room.cs
+++ b/Assets/ProcGenScripts/Room.cs
@@ -73,8 +73,9 @@ public class Room : MonoBehaviour
         _colliders.Add(ColliderType.EastDoor, CreateCollider(ColliderType.EastDoor));
         _colliders.Add(ColliderType.SouthDoor, CreateCollider(ColliderType.SouthDoor));
         _colliders.Add(ColliderType.WestDoor, CreateCollider(ColliderType.WestDoor));
-        // Add rigidbody to the room game object
-        gameObject.AddComponent<Rigidbody2D>();
+        // Add rigidbody to the room game object if it doesnt have one already
+        if (!gameObject.GetComponent<Rigidbody2D>())
+            gameObject.AddComponent<Rigidbody2D>();
         gameObject.GetComponent<Rigidbody2D>().bodyType = RigidbodyType2D.Static;
     }
 

--- a/Assets/ProcGenScripts/Room.cs
+++ b/Assets/ProcGenScripts/Room.cs
@@ -7,15 +7,15 @@ public class Room : MonoBehaviour
     public Room SouthRoom { get; set; } = null;
     public Room EastRoom { get; set; } = null;
     public Room WestRoom { get; set; } = null;
-    private RoomData roomData;
+    private RoomData _roomData;
     private readonly List<RoomData.Dir> availableDirections = new();
-    public bool visited;
-    private bool isStart;
-    private bool isEnd;
-    private readonly Dictionary<ColliderType, Collider2D> colliders = new();
+    public bool Visited;
+    private bool _isStart;
+    private bool _isEnd;
+    private readonly Dictionary<ColliderType, Collider2D> _colliders = new();
     // Getters for the room state flags
-    public bool Started => isStart;
-    public bool Ended => isEnd;
+    public bool Started => _isStart;
+    public bool Ended => _isEnd;
     // Specifies the colliders for the room
     // First direction in name is the direction to the wall
     // Second direction in name is relative to the doorway
@@ -36,35 +36,43 @@ public class Room : MonoBehaviour
         WestDoor
     }
 
+    // <summary>
+    /// Initializes the room object with the specified room data and position.
+    /// Sets the available directions from the specifications of theRoomData object
+    /// and creates colliders for the walls and doors. Adds a static rigidbody to
+    /// the room gameObject and configures its name and position.
+    /// </summary>
+    /// <param name="roomDataObject">The RoomData to configure this room with.</param>
+    /// <param name="position">The position of the center of the room relative to its parent.</param>
     public void Init(RoomData roomDataObject, Vector3 position)
     {
-        roomData = roomDataObject;
-        if (roomData.North) availableDirections.Add(RoomData.Dir.North);
-        if (roomData.East) availableDirections.Add(RoomData.Dir.East);
-        if (roomData.South) availableDirections.Add(RoomData.Dir.South);
-        if (roomData.West) availableDirections.Add(RoomData.Dir.West);
-        visited = false;
-        isStart = false;
-        isEnd = false;
+        _roomData = roomDataObject;
+        if (_roomData.North) availableDirections.Add(RoomData.Dir.North);
+        if (_roomData.East) availableDirections.Add(RoomData.Dir.East);
+        if (_roomData.South) availableDirections.Add(RoomData.Dir.South);
+        if (_roomData.West) availableDirections.Add(RoomData.Dir.West);
+        Visited = false;
+        _isStart = false;
+        _isEnd = false;
 
         // Create the room game object
         gameObject.transform.position = position;
         gameObject.transform.parent = transform;
-        gameObject.name = roomData.RoomName;
+        gameObject.name = _roomData.RoomName;
         // Create Colliders
-        colliders.Add(ColliderType.NorthWest, CreateCollider(ColliderType.NorthWest));
-        colliders.Add(ColliderType.NorthEast, CreateCollider(ColliderType.NorthEast));
-        colliders.Add(ColliderType.SouthWest, CreateCollider(ColliderType.SouthWest));
-        colliders.Add(ColliderType.SouthEast, CreateCollider(ColliderType.SouthEast));
-        colliders.Add(ColliderType.WestNorth, CreateCollider(ColliderType.WestNorth));
-        colliders.Add(ColliderType.WestSouth, CreateCollider(ColliderType.WestSouth));
-        colliders.Add(ColliderType.EastNorth, CreateCollider(ColliderType.EastNorth));
-        colliders.Add(ColliderType.EastSouth, CreateCollider(ColliderType.EastSouth));
+        _colliders.Add(ColliderType.NorthWest, CreateCollider(ColliderType.NorthWest));
+        _colliders.Add(ColliderType.NorthEast, CreateCollider(ColliderType.NorthEast));
+        _colliders.Add(ColliderType.SouthWest, CreateCollider(ColliderType.SouthWest));
+        _colliders.Add(ColliderType.SouthEast, CreateCollider(ColliderType.SouthEast));
+        _colliders.Add(ColliderType.WestNorth, CreateCollider(ColliderType.WestNorth));
+        _colliders.Add(ColliderType.WestSouth, CreateCollider(ColliderType.WestSouth));
+        _colliders.Add(ColliderType.EastNorth, CreateCollider(ColliderType.EastNorth));
+        _colliders.Add(ColliderType.EastSouth, CreateCollider(ColliderType.EastSouth));
         // Doors
-        colliders.Add(ColliderType.NorthDoor, CreateCollider(ColliderType.NorthDoor));
-        colliders.Add(ColliderType.EastDoor, CreateCollider(ColliderType.EastDoor));
-        colliders.Add(ColliderType.SouthDoor, CreateCollider(ColliderType.SouthDoor));
-        colliders.Add(ColliderType.WestDoor, CreateCollider(ColliderType.WestDoor));
+        _colliders.Add(ColliderType.NorthDoor, CreateCollider(ColliderType.NorthDoor));
+        _colliders.Add(ColliderType.EastDoor, CreateCollider(ColliderType.EastDoor));
+        _colliders.Add(ColliderType.SouthDoor, CreateCollider(ColliderType.SouthDoor));
+        _colliders.Add(ColliderType.WestDoor, CreateCollider(ColliderType.WestDoor));
         // Add rigidbody to the room game object
         gameObject.AddComponent<Rigidbody2D>();
         gameObject.GetComponent<Rigidbody2D>().bodyType = RigidbodyType2D.Static;
@@ -87,12 +95,21 @@ public class Room : MonoBehaviour
         };
     }
 
+    /// <summary>
+    /// Gets a randoim direction from the available directions.
+    /// </summary>
+    /// <returns>A random direction this room can connect to and North if none.</returns>
     public RoomData.Dir GetRandomDirection()
     {
         if (availableDirections.Count == 0) return RoomData.Dir.North;
         return availableDirections[Random.Range(0, availableDirections.Count)];
     }
 
+    /// <summary>
+    /// Returns the room in the specified direction.
+    /// </summary>
+    /// <param name="dir"></param>
+    /// <returns>The room Monobehavior for the specified direction. May be null.</returns>
     public Room GetRoomFromDirection(RoomData.Dir dir)
     {
         return dir switch
@@ -109,62 +126,65 @@ public class Room : MonoBehaviour
     /// Creates a collider for the room in the specified slot.
     /// </summary>
     /// <param name="type"></param>
-    /// <returns></returns>
+    /// <returns>A new collider created for the specified type</returns>
     private Collider2D CreateCollider(ColliderType type)
     {
         BoxCollider2D collider = gameObject.AddComponent<BoxCollider2D>();
-        float wallLength = roomData.Width / 2 - roomData.DoorSize.x / 2;
+        float wallLengthH = _roomData.Width / 2 - _roomData.DoorSize.x / 2;
+        float wallOffsetH = wallLengthH / 2 + _roomData.DoorSize.x / 2;
+        float wallLengthV = _roomData.Height / 2 - _roomData.DoorSize.x / 2;
+        float wallOffsetV = wallLengthV / 2 + _roomData.DoorSize.x / 2;
         switch (type)
         {
             // Doors
             case ColliderType.NorthDoor:
-                collider.size = new Vector2(roomData.DoorSize.x, roomData.DoorSize.y);
-                collider.offset = new Vector2(0, roomData.Height / 2);
+                collider.size = new Vector2(_roomData.DoorSize.x, _roomData.DoorSize.y);
+                collider.offset = new Vector2(0, _roomData.Height / 2);
                 break;
             case ColliderType.EastDoor:
-                collider.size = new Vector2(roomData.DoorSize.y, roomData.DoorSize.x);
-                collider.offset = new Vector2(roomData.Width / 2, 0);
+                collider.size = new Vector2(_roomData.DoorSize.y, _roomData.DoorSize.x);
+                collider.offset = new Vector2(_roomData.Width / 2, 0);
                 break;
             case ColliderType.SouthDoor:
-                collider.size = new Vector2(roomData.DoorSize.x, roomData.DoorSize.y);
-                collider.offset = new Vector2(0, -roomData.Height / 2);
+                collider.size = new Vector2(_roomData.DoorSize.x, _roomData.DoorSize.y);
+                collider.offset = new Vector2(0, -_roomData.Height / 2);
                 break;
             case ColliderType.WestDoor:
-                collider.size = new Vector2(roomData.DoorSize.y, roomData.DoorSize.x);
-                collider.offset = new Vector2(-roomData.Width / 2, 0);
+                collider.size = new Vector2(_roomData.DoorSize.y, _roomData.DoorSize.x);
+                collider.offset = new Vector2(-_roomData.Width / 2, 0);
                 break;
             // Directions
             case ColliderType.NorthWest:
-                collider.size = new Vector2(roomData.Width / 2 - roomData.DoorSize.x / 2, roomData.WallThickness);
-                collider.offset = new Vector2(-((roomData.Width / 2 - roomData.DoorSize.x / 2) / 2 + roomData.DoorSize.x / 2), roomData.Height / 2);
+                collider.size = new Vector2(wallLengthH, _roomData.WallThickness);
+                collider.offset = new Vector2(-wallOffsetH, _roomData.Height / 2);
                 break;
             case ColliderType.NorthEast:
-                collider.size = new Vector2(roomData.Width / 2 - roomData.DoorSize.x, roomData.WallThickness);
-                collider.offset = new Vector2(roomData.Width / 2, roomData.Height / 2);
+                collider.size = new Vector2(wallLengthH, _roomData.WallThickness);
+                collider.offset = new Vector2(wallOffsetH, _roomData.Height / 2);
                 break;
             case ColliderType.SouthWest:
-                collider.size = new Vector2(roomData.Width / 2 - roomData.DoorSize.x, roomData.WallThickness);
-                collider.offset = new Vector2(-roomData.DoorSize.x, -roomData.Height / 2);
+                collider.size = new Vector2(wallLengthH, _roomData.WallThickness);
+                collider.offset = new Vector2(-wallOffsetH, -_roomData.Height / 2);
                 break;
             case ColliderType.SouthEast:
-                collider.size = new Vector2(roomData.Width / 2 - roomData.DoorSize.x, roomData.WallThickness);
-                collider.offset = new Vector2(roomData.DoorSize.x, -roomData.Height / 2);
+                collider.size = new Vector2(wallLengthH, _roomData.WallThickness);
+                collider.offset = new Vector2(wallOffsetH, -_roomData.Height / 2);
                 break;
             case ColliderType.WestNorth:
-                collider.size = new Vector2(roomData.WallThickness, roomData.Height / 2 - roomData.DoorSize.x);
-                collider.offset = new Vector2(-roomData.Width / 2, roomData.DoorSize.x);
+                collider.size = new Vector2(_roomData.WallThickness, wallLengthV);
+                collider.offset = new Vector2(-_roomData.Width / 2, wallOffsetV);
                 break;
             case ColliderType.WestSouth:
-                collider.size = new Vector2(roomData.WallThickness, roomData.Height / 2 - roomData.DoorSize.x);
-                collider.offset = new Vector2(-roomData.Width / 2, -roomData.DoorSize.x);
+                collider.size = new Vector2(_roomData.WallThickness, wallLengthV);
+                collider.offset = new Vector2(-_roomData.Width / 2, -wallOffsetV);
                 break;
             case ColliderType.EastNorth:
-                collider.size = new Vector2(roomData.WallThickness, roomData.Height / 2 - roomData.DoorSize.x);
-                collider.offset = new Vector2(roomData.Width / 2, roomData.DoorSize.x / 2);
+                collider.size = new Vector2(_roomData.WallThickness, wallLengthV);
+                collider.offset = new Vector2(_roomData.Width / 2, wallOffsetV);
                 break;
             case ColliderType.EastSouth:
-                collider.size = new Vector2(roomData.WallThickness, roomData.Height / 2 - roomData.DoorSize.x);
-                collider.offset = new Vector2(roomData.Width / 2, -roomData.DoorSize.x / 2);
+                collider.size = new Vector2(_roomData.WallThickness, wallLengthV);
+                collider.offset = new Vector2(_roomData.Width / 2, -wallOffsetV);
                 break;
         }
         return collider;

--- a/Assets/ProcGenScripts/Room.cs.meta
+++ b/Assets/ProcGenScripts/Room.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16a4d48e94647cf4aba4047d2ec1e9d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ProcGenScripts/RoomData.cs
+++ b/Assets/ProcGenScripts/RoomData.cs
@@ -12,53 +12,58 @@ public class RoomData : ScriptableObject
         West
     }
     // Editor exposed setter variables
-    [Header("Room Position")]
     [SerializeField]
-    private int x;
-    [SerializeField]
-    private int y;
+    private string roomName;
     [Header("Room Size")]
     [SerializeField]
     private int width;
     [SerializeField]
     private int height;
+    [SerializeField]
+    private float wallThickness = 2f;
     [Header("Room Connections")]
     [SerializeField]
-    private bool North;
+    private bool north;
     [SerializeField]
-    private bool East;
+    private bool east;
     [SerializeField]
-    private bool South;
+    private bool south;
     [SerializeField]
-    private bool West;
+    private bool west;
     [Header("Door Size")]
     [SerializeField]
-    private int doorSize;
-
-    // Public getters for the room position
-    public int X => x;
-    public int Y => y;
-    // Public getters for the room size
-    public int Width => width;
-    public int Height => height;
-    // Public getter for the door size
-    public int DoorSize => doorSize;
+    private Vector2 doorSize;
 
     // Dictionary to store the connections
-    public readonly Dictionary<Dir, bool> connectDirs = new()
+    private readonly Dictionary<Dir, bool> connectDirs = new()
     {
         { Dir.North, false },
         { Dir.East, false },
         { Dir.South, false },
         { Dir.West, false }
     };
+
+    // Public getter properties for the room data
+
+    public string RoomName => roomName;
+    public int Width => width;
+    public int Height => height;
+    public Vector2 DoorSize => doorSize;
+    // Public getters for the room connections
+    public Dictionary<Dir, bool> ConnectDirs => connectDirs;
+    public bool North => north;
+    public bool East => east;
+    public bool South => south;
+    public bool West => west;
+    public float WallThickness => wallThickness;
+
     // On editor validate, update the dictionary
     // This is needed as Dictionary is not serializable
     private void OnValidate()
     {
-        connectDirs[Dir.North] = North;
-        connectDirs[Dir.East] = East;
-        connectDirs[Dir.South] = South;
-        connectDirs[Dir.West] = West;
+        connectDirs[Dir.North] = north;
+        connectDirs[Dir.East] = east;
+        connectDirs[Dir.South] = south;
+        connectDirs[Dir.West] = west;
     }
 }

--- a/Assets/ProcGenScripts/RoomData.cs
+++ b/Assets/ProcGenScripts/RoomData.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "RoomData", menuName = "ProcGen/Room", order = 1)]
+public class RoomData : ScriptableObject
+{
+    public enum Dir
+    {
+        North,
+        East,
+        South,
+        West
+    }
+    // Editor exposed setter variables
+    [Header("Room Position")]
+    [SerializeField]
+    private int x;
+    [SerializeField]
+    private int y;
+    [Header("Room Size")]
+    [SerializeField]
+    private int width;
+    [SerializeField]
+    private int height;
+    [Header("Room Connections")]
+    [SerializeField]
+    private bool North;
+    [SerializeField]
+    private bool East;
+    [SerializeField]
+    private bool South;
+    [SerializeField]
+    private bool West;
+    [Header("Door Size")]
+    [SerializeField]
+    private int doorSize;
+
+    // Public getters for the room position
+    public int X => x;
+    public int Y => y;
+    // Public getters for the room size
+    public int Width => width;
+    public int Height => height;
+    // Public getter for the door size
+    public int DoorSize => doorSize;
+
+    // Dictionary to store the connections
+    public readonly Dictionary<Dir, bool> connectDirs = new()
+    {
+        { Dir.North, false },
+        { Dir.East, false },
+        { Dir.South, false },
+        { Dir.West, false }
+    };
+    // On editor validate, update the dictionary
+    // This is needed as Dictionary is not serializable
+    private void OnValidate()
+    {
+        connectDirs[Dir.North] = North;
+        connectDirs[Dir.East] = East;
+        connectDirs[Dir.South] = South;
+        connectDirs[Dir.West] = West;
+    }
+}

--- a/Assets/ProcGenScripts/RoomData.cs.meta
+++ b/Assets/ProcGenScripts/RoomData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a7a484ec9ca84d49ba458b8468c4de9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**RoomData Scriptable Objects** define room types for dungeon generation. At the moment they only store size and connection data. The R**oom class is a MonoBehaviour** that takes in a RoomData object reference and initializes itself with its data. Does not update in real time to changes to the scriptable object but it would be fairly straightforward to implement if useful. The generation occurs in the DungeonGeneration Monobehaviour which has a **Coroutine called GenerateDungeon**. This performs a random grid walk and generates rooms from the list of spawnable rooms. This means that it must be attached to a game object in a scene where generation needs to occur and generation must be started by calling the coroutine.

The Room class will have methods to lock and unlock the room, enemy spawn locations and types, and data about objects within it so that they can be loaded when the player discovers the room. This will require updating the RoomData S.O. and will allow for a variety of room types to utilize the same class as almost all rooms share the same functions.